### PR TITLE
Update to latest stable cassandra

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        jdk: [8, 11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: "${{ matrix.jdk }}"
+        distribution: "adopt"
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Build
+      if: matrix.jdk == 8
+      run: mvn clean install --batch-mode -Djdk.version=1.${{ matrix.jdk }}
+    - name: Build
+      if: matrix.jdk != 8
+      run: mvn clean install --batch-mode -Djdk.version=${{ matrix.jdk }}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <cu.junit.version>4.12</cu.junit.version>
         <cu.logback.version>1.2.3</cu.logback.version>
-        <cu.cassandra.all.version>4.0-rc1</cu.cassandra.all.version>
+        <cu.cassandra.all.version>4.0.1</cu.cassandra.all.version>
         <cu.cassandra.driver.version>4.3.1</cu.cassandra.driver.version>
         <cu.spring.version>4.0.2.RELEASE</cu.spring.version>
         <cu.hamcrest.version>1.3</cu.hamcrest.version>


### PR DESCRIPTION
This updates to Cassandra `4.0.1`. Also, this adds CI that runs the tests using JDK 1.8 and 11 on gh actions.